### PR TITLE
feat(cli): implement dynamic help generation for CLI commands

### DIFF
--- a/src/clean_interfaces/interfaces/cli.py
+++ b/src/clean_interfaces/interfaces/cli.py
@@ -39,6 +39,9 @@ class CLIInterface(BaseInterface):
         """Set up CLI commands."""
         # Set the default command to welcome
         self.app.command(name="welcome")(self.welcome)
+        
+        # Add help command for dynamic help generation
+        self.app.command(name="help")(self.help)
 
         # Add a callback that shows welcome when no command is specified
         self.app.callback(invoke_without_command=True)(self._main_callback)
@@ -57,6 +60,81 @@ class CLIInterface(BaseInterface):
         console.print(msg.message)
         console.print(msg.hint)
         # Force flush to ensure output is visible
+        console.file.flush()
+
+    def help(self, command_name: str | None = None) -> None:
+        """Show available commands and their usage.
+        
+        Args:
+            command_name: Optional specific command to show help for
+        """
+        if command_name:
+            self._show_command_help(command_name)
+        else:
+            self._show_all_commands_help()
+
+    def _get_available_commands(self) -> dict[str, str]:
+        """Get all available commands with their descriptions.
+        
+        Returns:
+            dict: Mapping of command names to descriptions
+        """
+        commands = {}
+        
+        # Get commands from the Typer app
+        for command in self.app.registered_commands.values():
+            command_name = command.name or "unknown"
+            # Get the command description from the function docstring
+            description = self._get_command_description(command.callback)
+            commands[command_name] = description
+            
+        return commands
+
+    def _get_command_description(self, command_func: object) -> str:
+        """Extract description from command function.
+        
+        Args:
+            command_func: The command function
+            
+        Returns:
+            str: The command description
+        """
+        if hasattr(command_func, "__doc__") and command_func.__doc__:
+            # Get first line of docstring as description
+            return command_func.__doc__.strip().split('\n')[0]
+        return "No description available"
+
+    def _show_all_commands_help(self) -> None:
+        """Display help for all available commands."""
+        console.print("[bold blue]Available Commands:[/bold blue]")
+        console.print()
+        
+        commands = self._get_available_commands()
+        
+        for command_name, description in commands.items():
+            console.print(f"  [green]{command_name}[/green] - {description}")
+        
+        console.print()
+        console.print("[dim]Use 'help <command>' for detailed help on a specific command.[/dim]")
+        console.file.flush()
+
+    def _show_command_help(self, command_name: str) -> None:
+        """Display help for a specific command.
+        
+        Args:
+            command_name: Name of the command to show help for
+        """
+        commands = self._get_available_commands()
+        
+        if command_name not in commands:
+            console.print(f"[red]Error:[/red] Unknown command '{command_name}'")
+            console.print("Use 'help' to see all available commands.")
+            console.file.flush()
+            return
+            
+        description = commands[command_name]
+        console.print(f"[bold blue]Command:[/bold blue] {command_name}")
+        console.print(f"[bold blue]Description:[/bold blue] {description}")
         console.file.flush()
 
     def run(self) -> None:

--- a/tests/e2e/clean_interfaces/cli/test_cli_e2e.py
+++ b/tests/e2e/clean_interfaces/cli/test_cli_e2e.py
@@ -205,3 +205,103 @@ class TestCLIE2E:
 
         # Should produce output
         assert len(output) > 0  # type: ignore[arg-type]
+
+    def test_cli_dynamic_help_command(
+        self,
+        clean_env: dict[str, str],
+    ) -> None:
+        """Test that CLI dynamic help command works."""
+        # Use pexpect.run() to capture output
+        try:
+            result = pexpect.run(  # type: ignore[attr-defined]
+                f"{sys.executable} -u -m clean_interfaces.main help",
+                env=clean_env,  # type: ignore[arg-type]
+                withexitstatus=True,
+                timeout=5,
+                encoding="utf-8",
+            )
+            # pexpect.run returns (output, exitstatus) when withexitstatus=True
+            if isinstance(result, tuple):  # type: ignore[arg-type]
+                output, exitstatus = result  # type: ignore[misc]
+            else:
+                # Handle unexpected return format
+                output = str(result)
+                exitstatus = 0
+        except pexpect.TIMEOUT:
+            error_msg = "Timeout waiting for CLI help command to complete"
+            raise AssertionError(error_msg) from None
+
+        # Check exit code
+        assert exitstatus == 0
+
+        # Check help output contains expected content
+        assert "Available Commands:" in output
+        assert "welcome" in output
+        assert "help" in output
+
+    def test_cli_help_shows_all_commands(
+        self,
+        clean_env: dict[str, str],
+    ) -> None:
+        """Test that CLI help shows all available commands dynamically."""
+        # Use pexpect.run() to capture output
+        try:
+            result = pexpect.run(  # type: ignore[attr-defined]
+                f"{sys.executable} -u -m clean_interfaces.main help",
+                env=clean_env,  # type: ignore[arg-type]
+                withexitstatus=True,
+                timeout=5,
+                encoding="utf-8",
+            )
+            # pexpect.run returns (output, exitstatus) when withexitstatus=True
+            if isinstance(result, tuple):  # type: ignore[arg-type]
+                output, exitstatus = result  # type: ignore[misc]
+            else:
+                # Handle unexpected return format
+                output = str(result)
+                exitstatus = 0
+        except pexpect.TIMEOUT:
+            error_msg = "Timeout waiting for CLI help to show all commands"
+            raise AssertionError(error_msg) from None
+
+        # Check exit code
+        assert exitstatus == 0
+
+        # Check that all expected commands are listed
+        assert "welcome" in output
+        assert "help" in output
+        # Check for command descriptions
+        assert "Display welcome message" in output
+        assert "Show available commands and their usage" in output
+
+    def test_cli_help_with_specific_command(
+        self,
+        clean_env: dict[str, str],
+    ) -> None:
+        """Test that CLI help shows specific command details."""
+        # Use pexpect.run() to capture output
+        try:
+            result = pexpect.run(  # type: ignore[attr-defined]
+                f"{sys.executable} -u -m clean_interfaces.main help welcome",
+                env=clean_env,  # type: ignore[arg-type]
+                withexitstatus=True,
+                timeout=5,
+                encoding="utf-8",
+            )
+            # pexpect.run returns (output, exitstatus) when withexitstatus=True
+            if isinstance(result, tuple):  # type: ignore[arg-type]
+                output, exitstatus = result  # type: ignore[misc]
+            else:
+                # Handle unexpected return format
+                output = str(result)
+                exitstatus = 0
+        except pexpect.TIMEOUT:
+            error_msg = "Timeout waiting for CLI command-specific help"
+            raise AssertionError(error_msg) from None
+
+        # Check exit code
+        assert exitstatus == 0
+
+        # Check that specific command help is shown
+        assert "welcome" in output
+        assert "Display welcome message" in output

--- a/tests/unit/clean_interfaces/interfaces/test_cli.py
+++ b/tests/unit/clean_interfaces/interfaces/test_cli.py
@@ -53,3 +53,58 @@ class TestCLIInterface:
         cli.run()
 
         cli.app.assert_called_once()
+
+    def test_help_command_exists(self) -> None:
+        """Test that help command is registered."""
+        cli = CLIInterface()
+        
+        # Check that help command is in the app's commands
+        commands = [cmd.name for cmd in cli.app.registered_commands.values()]
+        assert "help" in commands
+
+    def test_help_generation_methods(self) -> None:
+        """Test help generation logic."""
+        cli = CLIInterface()
+        
+        # Test that help generation method exists
+        assert hasattr(cli, "help")
+        assert callable(cli.help)
+
+    def test_command_discovery(self) -> None:
+        """Test command discovery functionality."""
+        cli = CLIInterface()
+        
+        # Test that CLI can discover its own commands
+        commands = cli._get_available_commands()
+        assert isinstance(commands, dict)
+        assert "welcome" in commands
+        assert "help" in commands
+
+    def test_help_formatting(self) -> None:
+        """Test help text formatting."""
+        cli = CLIInterface()
+        
+        # Mock the console output
+        with patch("clean_interfaces.interfaces.cli.console") as mock_console:
+            cli.help()
+            
+            # Check that help was displayed
+            assert mock_console.print.called
+            
+            # Get the call args to check content
+            call_args = mock_console.print.call_args_list
+            output_text = str(call_args)
+            
+            # Check for expected help content
+            assert "Available Commands:" in output_text or any("Available Commands:" in str(call) for call in call_args)
+
+    def test_help_with_specific_command(self) -> None:
+        """Test help for specific command."""
+        cli = CLIInterface()
+        
+        # Mock the console output
+        with patch("clean_interfaces.interfaces.cli.console") as mock_console:
+            cli.help("welcome")
+            
+            # Check that specific command help was displayed
+            assert mock_console.print.called


### PR DESCRIPTION
Implements dynamic CLI help generation as requested in issue #12

## Summary
- Add dynamic command discovery from Typer app
- Implement help command with general and specific command help
- Add automatic description extraction from docstrings
- Include Rich console formatting for better readability
- Add comprehensive E2E and unit tests for help functionality

## Test Plan
- Run `nox -s test` to verify all tests pass
- Test `help` command manually: `uv run python -m clean_interfaces.main help`
- Test specific command help: `uv run python -m clean_interfaces.main help welcome`
- Verify quality checks pass: `nox -s lint && nox -s typing`

Closes #12

Generated with [Claude Code](https://claude.ai/code)