### PR TITLE
Adapt vscode extension settings for cursor editor

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,47 @@
 {
+  "name": "clean-interfaces",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "root",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
+        "ms-azuretools.vscode-docker",
+        "tamasfe.even-better-toml",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "python.analysis.stubPath": "typings",
+        "python.analysis.typeCheckingMode": "strict",
+        "python.analysis.useLibraryCodeForTypes": true,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ],
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll": true
+        },
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "bash -lc 'if [ ! -d .venv ]; then uv venv .venv; fi && . .venv/bin/activate && uv pip install -e .[dev]'",
+  "postAttachCommand": "bash -lc '.devcontainer/select-editor.sh'"
+}
+
+{
   "name": "Claude Code Python Dev Sandbox",
   "build": {
     "dockerfile": "Dockerfile",

--- a/.devcontainer/select-editor.sh
+++ b/.devcontainer/select-editor.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${PWD}"
+
+detect_editor_flavor() {
+  # Allow manual override
+  if [[ "${EDITOR_FLAVOR:-}" =~ ^(vscode|cursor)$ ]]; then
+    echo "${EDITOR_FLAVOR}"
+    return
+  fi
+
+  # VS Code/ Cursor remote server folder hint
+  if [[ -n "${VSCODE_AGENT_FOLDER:-}" ]]; then
+    if [[ "${VSCODE_AGENT_FOLDER}" == *".cursor-server"* ]]; then
+      echo "cursor"; return
+    fi
+    if [[ "${VSCODE_AGENT_FOLDER}" == *".vscode-server"* ]]; then
+      echo "vscode"; return
+    fi
+  fi
+
+  # Server installation directories
+  if [[ -d "${HOME}/.cursor-server" ]]; then
+    echo "cursor"; return
+  fi
+  if [[ -d "${HOME}/.vscode-server" ]]; then
+    echo "vscode"; return
+  fi
+
+  # Terminal program hint
+  case "${TERM_PROGRAM:-}" in
+    cursor|*Cursor*) echo "cursor"; return ;;
+    vscode|*VSCode*) echo "vscode"; return ;;
+  esac
+
+  # Default
+  echo "vscode"
+}
+
+flavor="$(detect_editor_flavor)"
+echo "[devcontainer] Detected editor flavor: ${flavor}"
+
+mkdir -p "${workspace}/.vscode"
+
+pushd "${workspace}/.vscode" >/dev/null
+
+# Link editor-specific settings
+if [[ -f "settings.${flavor}.json" ]]; then
+  ln -sf "settings.${flavor}.json" "settings.json"
+elif [[ -f "settings.vscode.json" ]]; then
+  ln -sf "settings.vscode.json" "settings.json"
+fi
+
+# Link editor-specific extension recommendations
+if [[ -f "extensions.${flavor}.json" ]]; then
+  ln -sf "extensions.${flavor}.json" "extensions.json"
+elif [[ -f "extensions.vscode.json" ]]; then
+  ln -sf "extensions.vscode.json" "extensions.json"
+fi
+
+popd >/dev/null
+
+# Ensure venv exists and install dev deps
+if [[ ! -d "${workspace}/.venv" ]]; then
+  echo "[devcontainer] Creating Python venv with uv..."
+  uv venv "${workspace}/.venv"
+  source "${workspace}/.venv/bin/activate"
+  uv pip install -e "${workspace}.[dev]"
+fi
+
+echo "[devcontainer] Editor-specific settings linked: ${flavor}"
+

--- a/.vscode/extensions.cursor.json
+++ b/.vscode/extensions.cursor.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "ms-toolsai.jupyter",
+    "ms-azuretools.vscode-docker",
+    "tamasfe.even-better-toml",
+    "esbenp.prettier-vscode"
+  ],
+  "unwantedRecommendations": []
+}
+

--- a/.vscode/extensions.vscode.json
+++ b/.vscode/extensions.vscode.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "ms-toolsai.jupyter",
+    "ms-azuretools.vscode-docker",
+    "tamasfe.even-better-toml",
+    "esbenp.prettier-vscode"
+  ],
+  "unwantedRecommendations": []
+}
+

--- a/.vscode/settings.cursor.json
+++ b/.vscode/settings.cursor.json
@@ -1,0 +1,30 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.analysis.stubPath": "typings",
+  "python.analysis.typeCheckingMode": "strict",
+  "python.analysis.useLibraryCodeForTypes": true,
+  "python.analysis.extraPaths": [
+    "src"
+  ],
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "ruff.showNotifications": "off",
+  "ruff.organizeImports": true,
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.mypy_cache": true,
+    "**/.pytest_cache": true,
+    ".venv": true,
+    ".ruff_cache": true
+  }
+}
+

--- a/.vscode/settings.vscode.json
+++ b/.vscode/settings.vscode.json
@@ -1,0 +1,30 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.analysis.stubPath": "typings",
+  "python.analysis.typeCheckingMode": "strict",
+  "python.analysis.useLibraryCodeForTypes": true,
+  "python.analysis.extraPaths": [
+    "src"
+  ],
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "ruff.showNotifications": "off",
+  "ruff.organizeImports": true,
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.mypy_cache": true,
+    "**/.pytest_cache": true,
+    ".venv": true,
+    ".ruff_cache": true
+  }
+}
+


### PR DESCRIPTION
Enable editor-specific extension settings in dev containers for both VS Code and Cursor.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fa0d04a-0723-49b4-8a09-ef6a7d2ae55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7fa0d04a-0723-49b4-8a09-ef6a7d2ae55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

