### PR TITLE
Update pip constraint to 25.3

### DIFF
--- a/constraints/python3.12-linux-x86_64.txt
+++ b/constraints/python3.12-linux-x86_64.txt
@@ -273,7 +273,7 @@ pdm==2.25.4
     # via testproject (pyproject.toml)
 pexpect==4.9.0
     # via hatch
-pip==25.1.1
+pip==25.3
     # via pip-api
 pip-api==0.0.34
     # via pip-audit

--- a/constraints/python3.13-linux-x86_64.txt
+++ b/constraints/python3.13-linux-x86_64.txt
@@ -243,7 +243,7 @@ pexpect==4.9.0
     # via
     #   clean-interfaces (pyproject.toml)
     #   hatch
-pip==25.2
+pip==25.3
     # via pip-api
 pip-api==0.0.34
     # via pip-audit


### PR DESCRIPTION
## Summary
- update pip constraints for Python 3.12 and 3.13 environments to patched version 25.3 to address GHSA-4xh5-x5gv-qwph

## Testing
- nox -s security --non-interactive *(fails in CI image: command not found in local environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211bd40cc0833082f089629b7af755)